### PR TITLE
fixed open_basedir restriction

### DIFF
--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -697,7 +697,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI
             $newObj->setPermissions($_GET["ref_id"]);
         }
 
-        if (is_file($_SESSION["qpl_import_dir"] . '/' . $_SESSION["qpl_import_subdir"] . "/manifest.xml")) {
+        if (@is_file($_SESSION["qpl_import_dir"] . '/' . $_SESSION["qpl_import_subdir"] . "/manifest.xml")) {
             $_SESSION["qpl_import_idents"] = $_POST["ident"];
             
             $fileName = $_SESSION["qpl_import_subdir"] . '.zip';


### PR DESCRIPTION
Fixed an error when open_basedir restriction is in place and the $_SESSION variables are not set.

Not set $_SESSION variables result in a filename like //manifest.xml which is not in the permitted paths and the execution of the script crashes.

To reproduce, restrict the execution of the php script to /tmp and the upload and main folder of ILIAS.